### PR TITLE
Enable incremental builds, add support for non-US keyboards

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -25,4 +25,4 @@ ENV LC_ALL en_US.UTF-8
 
 WORKDIR "/sedutil"
 
-CMD "/sedutil/images/autobuild.sh"
+CMD ["/sedutil/images/autobuild.sh","-h"]

--- a/images/README.md
+++ b/images/README.md
@@ -7,17 +7,23 @@ Docker can be used as a repeatable build environment to build the images in an U
 
 ### Step 1 - Build the Docker container
 
-    docker build -t sedutil .
+    sudo docker build -t sedutil .
 
 ### Step 2 - Run the build from within the Docker container
 
-Try the `autobuild.sh` script which runs automatically when no command is
-passed:
+To explore build options, run the Docker container without arguments:
 
-    docker run --rm -it -v $PWD/../:/sedutil --privileged sedutil
+    sudo docker run --rm -it -v $PWD/../:/sedutil --privileged sedutil
+
+For a complete build with US keyboard support, run:
+
+    sudo docker run --rm -it -v $PWD/../:/sedutil --privileged sedutil /sedutil/images/autobuild.sh complete
+
+To rebuild with German keyboard support, run:
+
+    sudo docker run --rm -it -v $PWD/../:/sedutil --privileged sedutil /sedutil/images/autobuild.sh -k qwertz/de-latin1 images dist
 
 Or, refer to `BUILDING` file and run manually in the Docker container by
 starting `bash`:
 
-    docker run --rm -it -v $PWD/../:/sedutil --privileged sedutil bash
-
+    sudo docker run --rm -it -v $PWD/../:/sedutil --privileged sedutil bash

--- a/images/autobuild.sh
+++ b/images/autobuild.sh
@@ -1,7 +1,56 @@
 #!/bin/bash
 
-# Echo commands and abort on error
-set -ex
+ME="$(basename $0)"
+
+function usage() {
+    {
+        [[ $# -gt 0 ]] && echo "$ME: $*"
+        echo "usage: $ME [-h] [-k <keymap>] [<step> ...]"
+        echo ""
+        echo "Executes the build steps according to <step> arguments."
+        echo "   <step>: complete|pbaroot|pba|cli|images|dist"
+        echo ""
+        echo "Options:"
+        echo "   -k <keymap>: build for non-US keyboard, see http://distro.ibiblio.org/tinycorelinux/faq.html#keyboard"
+        echo "      Example for German: -k qwertz/de-latin1"
+        echo "   -h: print this help message"
+        echo ""
+        echo "Each build step mentioned in a <step> argument is executed unconditionally."
+        echo ""
+        echo "Build steps not mentioned in <step> arguments are executed only if their result does not exist yet."
+        echo "'complete' will re-build everything from scratch."
+        echo ""
+        echo "By default, builds support US keyboards only. To rebuild for a different keyboard, use the '-k' option"
+        echo "and include build steps 'images' and 'dist'."
+    } >&2
+    exit 1
+}
+
+# Build arguments:
+
+export BUILD_KEYMAP=""
+
+while [[ $# -gt 0 ]] && [[ "$1" =~ ^- ]]; do
+    option="$1"
+    shift
+    case "$option" in
+        "-k")
+            [[ $# -lt 1 ]] && usage "option \"-k\" requires a keymap argument"
+            BUILD_KEYMAP="$1"
+            shift
+            ;;
+        "-h")
+            usage
+            ;;
+        *)
+            usage "invalid option \"$option\""
+    esac
+done
+
+BUILD_STEPS="$*"
+
+# Abort on error
+set -e
 
 # Optimal MAKEFLAGS argument if not already defined
 if [ -z ${MAKEFLAGS+x} ]; then
@@ -14,34 +63,95 @@ cd "$( dirname "${BASH_SOURCE[0]}" )"
 
 source conf
 
-# Build buildroot before other tools as it provides the toolchain for linuxpba
-# and sedutil-cli.
-./getresources
-./buildpbaroot
+if [[ ! -f scratch/setfont.tcz ]]; then
+    BUILD_STEPS+=" complete"
+else
+    [[ -d scratch/buildroot/PBA64 ]] || BUILD_STEPS+=" pbaroot"
+    [[ -f ../LinuxPBA/dist/Release_x86_64/GNU-Linux/linuxpba ]] || BUILD_STEPS+=" pba"
+    [[ -f ../linux/CLI/dist/Release_x86_64/GNU-Linux/sedutil-cli ]] || BUILD_STEPS+=" cli"
+    [[ -f $(echo UEFI64_Release/UEFI64_Release-*.img.gz) ]] || BUILD_STEPS+=" images"
+    [[ -f ../dist/sedutil-cli ]] || BUILD_STEPS+=" dist"
+fi
 
-pushd ../LinuxPBA
-rm -rf dist build
-make CONF=Debug
-make CONF=Debug_x86_64
-make CONF=Release
-make CONF=Release_x86_64
-popd
+echo -e "\n*** $0 starting, build steps: ${BUILD_STEPS:-(none)}, keymap: ${BUILD_KEYMAP:-(default)} ***"
 
-pushd ../linux/CLI
-rm -rf dist build
-make CONF=Debug_i686
-make CONF=Debug_x86_64
-make CONF=Release_i686
-make CONF=Release_x86_64
-popd
+case "$BUILD_STEPS" in
+    *complete*)
+        echo -e "\n*** Getting resources ***"
 
-# Build BIOS images (untested, probably subtly broken)
-#./buildbiospba Release
-#./buildbiospba Debug
+        ./getresources
+        ;;
+esac
 
-# Build UEFI images
-./buildUEFI64 Release
-./buildUEFI64 Debug
+case "$BUILD_STEPS" in
+    *complete*|*pbaroot*)
+        echo -e "\n*** Building PBA root systems ***"
 
-# Rescue build
-./buildrescue
+        # Build buildroot before other tools as it provides the toolchain for linuxpba
+        # and sedutil-cli.
+        ./buildpbaroot
+        ;;
+esac
+
+case "$BUILD_STEPS" in
+    *complete*|*pba*)
+        echo -e "\n*** Building PBA executables ***"
+
+        pushd ../LinuxPBA
+        rm -rf dist build
+        make CONF=Debug
+        make CONF=Debug_x86_64
+        make CONF=Release
+        make CONF=Release_x86_64
+        popd
+        ;;
+esac
+
+case "$BUILD_STEPS" in
+    *complete*|*cli*)
+        echo -e "\n*** Building CLI executables ***"
+
+        pushd ../linux/CLI
+        rm -rf dist build
+        make CONF=Debug_i686
+        make CONF=Debug_x86_64
+        make CONF=Release_i686
+        make CONF=Release_x86_64
+        popd
+        ;;
+esac
+
+case "$BUILD_STEPS" in
+    *complete*|*images*)
+        echo -e "\n*** Building images ***"
+
+        # Build BIOS images (untested, probably subtly broken)
+        #./buildbiospba Release
+        #./buildbiospba Debug
+
+        # Build UEFI images
+        ./buildUEFI64 Release
+        ./buildUEFI64 Debug
+
+        # Rescue build
+        ./buildrescue
+        ;;
+esac
+
+case "$BUILD_STEPS" in
+    *complete*|*dist*)
+        echo -e "\n*** Building distribution ***"
+
+        [ -d ../dist ] && rm -rf ../dist
+        mkdir -p ../dist/images
+        cd ../dist
+        for file in ../images/{UEFI64_*,Rescue}/*.img.gz; do
+            zcat "$file" > images/"$(basename ${file%.gz})"
+        done
+        cp ../linux/CLI/dist/Release_x86_64/GNU-Linux/sedutil-cli .
+
+        ls -lR "$(pwd)"
+        ;;
+esac
+
+echo -e "\n*** Completed ***"

--- a/images/buildUEFI64
+++ b/images/buildUEFI64
@@ -20,12 +20,26 @@ fi
      -f ../LinuxPBA/dist/${BUILDTYPE}_x86_64/GNU-Linux/linuxpba -a \
      -f ../linux/CLI/dist/${BUILDTYPE}_x86_64/GNU-Linux/sedutil-cli -a \
       -f scratch/buildroot/PBA64/images/bzImage  -a \
-      -f buildroot/syslinux.cfg \
+      -f buildroot/syslinux.cfg -a \
+     -f scratch/kmaps.tcz \
   ] || { echo " prereqs are not available "; exit 1; }
 # recreate the initrd file with the latest PBA
 mkdir -p scratch/buildroot/PBA64/overlay/sbin/
 cp ../LinuxPBA/dist/${BUILDTYPE}_x86_64/GNU-Linux/linuxpba  scratch/buildroot/PBA64/overlay/sbin/linuxpba
 cp ../linux/CLI/dist/${BUILDTYPE}_x86_64/GNU-Linux/sedutil-cli  scratch/buildroot/PBA64/overlay/sbin/sedutil-cli
+if [[ -n "$BUILD_KEYMAP" ]]; then
+mkdir -m u=rwx,go=rx -p scratch/buildroot/PBA64/overlay/etc/init.d
+cat << -END-
+#!/bin/sh
+KEYBOARD="$BUILD_KEYMAP"
+loadkmap < "/usr/share/kmap/\$KEYBOARD.kmap" && echo "Keyboard set to \$KEYBOARD" || { echo "Keyboard setup for \$KEYBOARD failed."; sleep 2; }
+-END-
+else
+echo "# Do not process /etc/init.d scripts"
+fi > scratch/buildroot/PBA64/overlay/etc/init.d/rcS
+echo "# Do not process /etc/init.d scripts" > scratch/buildroot/PBA64/overlay/etc/init.d/rcK
+chmod a=rx scratch/buildroot/PBA64/overlay/etc/init.d/rc?
+sudo unsquashfs -f -d scratch/buildroot/PBA64/overlay scratch/kmaps.tcz
 cd scratch/buildroot
 make all O=PBA64 2>&1 >PBA64.log
 cd ../..
@@ -33,7 +47,7 @@ cd ../..
 sudo rm -rf UEFI64_${BUILDTYPE} ; mkdir UEFI64_${BUILDTYPE} ; cd UEFI64_${BUILDTYPE}
 # make an image file
 dd if=/dev/zero of=${BUILDIMG} bs=1M count=7
-(echo "n";echo "";echo "";echo "";echo "ef00";echo w;echo Y) | gdisk ${BUILDIMG}
+(echo "n"; echo ""; echo ""; echo ""; echo "ef00"; echo w; echo Y) | gdisk ${BUILDIMG}
 
 LOOPDEV=`sudo losetup --show -f -o 1048576 ${BUILDIMG}`
 sudo mkfs.vfat $LOOPDEV -n UEFI64_${BUILDTYPE}

--- a/images/buildrescue
+++ b/images/buildrescue
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -e
 # Build a custom tinycore bootable image
 ## define releases for tools
 . conf
@@ -15,6 +15,8 @@ sudo rm -rf ${BUILDTYPE} ; mkdir ${BUILDTYPE} ; cd ${BUILDTYPE}
      -f ../scratch/core.gz -a \
      -f ../scratch/vmlinuz -a \
      -f ../scratch/hdparm.tcz -a \
+     -f ../scratch/kmaps.tcz -a \
+     -f ../scratch/setfont.tcz -a \
      -f ${PROGRAM} \
   ] || { echo " prereqs are not available "; exit 1; }
 #
@@ -36,17 +38,30 @@ echo "label DTA" >>image/boot/extlinux/extlinux.conf
 echo "    kernel /boot/vmlinuz" >>image/boot/extlinux/extlinux.conf
 echo "    initrd /boot/core.gz" >>image/boot/extlinux/extlinux.conf
 echo "    append loglevel=0 libata.allow_tpm=1 tinycore base norestore noswap superuser" >>image/boot/extlinux/extlinux.conf
-## Remaster the initrd 
+## Remaster the initrd
 mkdir core
 cd core
 zcat ../../scratch/core.gz | sudo cpio -i -H newc -d
 cd ..
 sudo mkdir -p core/usr/local/sbin/
-sudo unsquashfs -f -li -d core ../scratch/hdparm.tcz
+sudo unsquashfs -f -d core ../scratch/hdparm.tcz
+sudo unsquashfs -f -d core ../scratch/kmaps.tcz
+sudo unsquashfs -f -d core ../scratch/setfont.tcz
+if [[ -n "$BUILD_KEYMAP" ]]; then
+cat << -END- > core/opt/bootlocal.sh
+#!/bin/sh
+KEYBOARD="$BUILD_KEYMAP"
+loadkmap < "/usr/share/kmap/\$KEYBOARD.kmap" && echo "Keyboard set to \$KEYBOARD" || echo "Keyboard setup for \$KEYBOARD failed."
+kbd_mode -u  # Switch keyboard to UTF-8 mode
+setfont default8x16  # Load font with UTF-8 mapping info (.psfu extension)
+-END-
+chmod a=rx core/opt/bootlocal.sh
+fi
 sudo cp ${PROGRAM} core/usr/local/sbin/
-## Bundle UEFI images
-sudo gunzip -k /sedutil/images/UEFI*/*.gz
-sudo cp /sedutil/images/UEFI*/*.img core/
+## Bundle UEFI images to /root
+for file in /sedutil/images/UEFI*/*.img.gz; do
+    zcat "$file" > core/root/"$(basename ${file%.gz})"
+done
 ## now repackage it
 cd core
 sudo find | sudo cpio -o -H newc | gzip -9 > ../image/boot/core.gz

--- a/images/buildroot/PBA32/setup.sh
+++ b/images/buildroot/PBA32/setup.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-rm PBA32/target/etc/init.d/*
-sed -i '1,1s/\*//' PBA32/target/etc/shadow 
+sed -i '1,1s/\*//' PBA32/target/etc/shadow
 exit 0

--- a/images/buildroot/PBA64/setup.sh
+++ b/images/buildroot/PBA64/setup.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-rm PBA64/target/etc/init.d/*
 sed -i '1,1s/\*//' PBA64/target/etc/shadow
 exit 0

--- a/images/getresources
+++ b/images/getresources
@@ -11,6 +11,8 @@ wget ${TCDISTRO}/release/${TINYCORE}
 ##wget ${TCDISTRO}/tcz/ncurses-common.tcz
 wget ${TCDISTRO}/tcz/ncurses.tcz
 wget ${TCDISTRO}/tcz/hdparm.tcz
+wget ${TCDISTRO}/tcz/kmaps.tcz
+wget ${TCDISTRO}/tcz/setfont.tcz
 wget https://www.kernel.org/pub/linux/utils/boot/syslinux/${SYSLINUX}.tar.xz
 ##   Unpack Syslinux
 tar xf ${SYSLINUX}.tar.xz 


### PR DESCRIPTION
This pull request fixes #9 and also includes support for keyboard maps in the Rescue and PBA images.

For instructions, see [images/README.md](https://github.com/OliverO2/sedutil/blob/a4d9d16ec5f606fdd08773a19238a01f6299ba1e/images/README.md).